### PR TITLE
Adding print() parentheses to ensure python 3 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ endif(PYTHON_EXECUTABLE)
 if(NOT DEFINED GR_PYTHON_DIR)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
 from distutils import sysconfig
-print sysconfig.get_python_lib(plat_specific=True, prefix='')
+print(sysconfig.get_python_lib(plat_specific=True, prefix=''))
 " OUTPUT_VARIABLE GR_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 endif()


### PR DESCRIPTION
gr-compat will not build on a machine running python3 and gnuradio 3.8.

This small change will get it to build (at least on my machine ubuntu/python3.6.9/PyBOMBS2.3.4a0 - have not done extensive testing).